### PR TITLE
Instead of acting as a strange LED mode, use a loop hook instead

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -43,6 +43,7 @@ const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
 
   if (Layer.isOn(numPadLayer)) {
     Layer.off(numPadLayer);
+    LEDControl.init_mode();
   } else {
     Layer.on(numPadLayer);
   }

--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -3,31 +3,22 @@
 #include "Kaleidoscope.h"
 #include "layers.h"
 
-uint8_t NumLock_::previousLEDMode;
-uint8_t NumLock_::us;
 bool NumLock_::isActive;
 byte NumLock_::row = 255, NumLock_::col = 255;
-cRGB numpad_color;
+cRGB numpad_color = CRGB(255, 0, 0);
 
 
 NumLock_::NumLock_(void) {
 }
 
-void
-NumLock_::begin(void) {
-  us = LEDControl.mode_add(this);
-  numpad_color.r = 255;
+void NumLock_::begin(void) {
+  loop_hook_use(loopHook);
 }
 
-void
-NumLock_::init(void) {
-  if (!isActive) {
-    LEDControl.next_mode();
-  }
-}
+void NumLock_::loopHook(bool postClear) {
+  if (!postClear || !isActive)
+    return;
 
-void
-NumLock_::update(void) {
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
       Key k = Layer.lookup(r, c);
@@ -46,21 +37,16 @@ NumLock_::update(void) {
   LEDControl.led_set_crgb_at(row, col, color);
 }
 
-const macro_t *
-NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
+const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
   row = row_;
   col = col_;
 
   if (Layer.isOn(numPadLayer)) {
-    isActive = false;
-    LEDControl.set_mode(previousLEDMode);
     Layer.off(numPadLayer);
   } else {
-    isActive = true;
-    previousLEDMode = LEDControl.get_mode();
-    LEDControl.set_mode(us);
     Layer.on(numPadLayer);
   }
+  isActive = Layer.isOn(numPadLayer);
 
   return MACRO(T(KeypadNumLock), END);
 }

--- a/src/Kaleidoscope-Numlock.h
+++ b/src/Kaleidoscope-Numlock.h
@@ -7,20 +7,16 @@
 #define TOGGLENUMLOCK 0
 #define Key_ToggleNumlock M(TOGGLENUMLOCK)
 
-class NumLock_ : public LEDMode {
+class NumLock_ : public KaleidoscopePlugin {
  public:
   NumLock_(void);
 
   void begin(void) final;
 
-  void update(void) final;
-  void init(void) final;
-
   static const macro_t *toggle(byte row, byte col, uint8_t numPadLayer);
+  static void loopHook(const bool postClear);
 
  private:
-  static uint8_t previousLEDMode;
-  static uint8_t us;
   static bool isActive;
   static byte row, col;
 };


### PR DESCRIPTION
Having the LED effects of the NumLock layer as a special LED mode has a number of drawbacks, like not interacting well with led mode switching: one can't get back to the NumLock effect once switching away from it (but the mode remains active nevertheless).

To avoid this and other issues, don't make the effect a LED mode. Instead, override the active LED mode with the numlock layer colors. This way, it is always in sync with the layer.