### PR TITLE
API Friendliness

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -43,6 +43,7 @@ const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
 
   if (Layer.isOn(numPadLayer)) {
     Layer.off(numPadLayer);
+    LEDControl.init_mode();
   } else {
     Layer.on(numPadLayer);
   }

--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -3,10 +3,9 @@
 #include "Kaleidoscope.h"
 #include "layers.h"
 
-bool NumLock_::isActive;
 byte NumLock_::row = 255, NumLock_::col = 255;
+uint8_t NumLock_::numPadLayer;
 cRGB numpad_color = CRGB(255, 0, 0);
-
 
 NumLock_::NumLock_(void) {
 }
@@ -16,7 +15,7 @@ void NumLock_::begin(void) {
 }
 
 void NumLock_::loopHook(bool postClear) {
-  if (!postClear || !isActive)
+  if (!postClear || !Layer.isOn(numPadLayer))
     return;
 
   for (uint8_t r = 0; r < ROWS; r++) {
@@ -37,9 +36,9 @@ void NumLock_::loopHook(bool postClear) {
   LEDControl.led_set_crgb_at(row, col, color);
 }
 
-const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
-  row = row_;
-  col = col_;
+const macro_t *NumLock_::toggle() {
+  row = Macros.row;
+  col = Macros.col;
 
   if (Layer.isOn(numPadLayer)) {
     Layer.off(numPadLayer);
@@ -47,7 +46,6 @@ const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
   } else {
     Layer.on(numPadLayer);
   }
-  isActive = Layer.isOn(numPadLayer);
 
   return MACRO(T(KeypadNumLock), END);
 }

--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -3,31 +3,22 @@
 #include "Kaleidoscope.h"
 #include "layers.h"
 
-uint8_t NumLock_::previousLEDMode;
-uint8_t NumLock_::us;
 bool NumLock_::isActive;
 byte NumLock_::row = 255, NumLock_::col = 255;
-cRGB numpad_color;
+cRGB numpad_color = CRGB(255, 0, 0);
 
 
 NumLock_::NumLock_(void) {
 }
 
-void
-NumLock_::begin(void) {
-  us = LEDControl.mode_add(this);
-  numpad_color.r = 255;
+void NumLock_::begin(void) {
+  loop_hook_use(loopHook);
 }
 
-void
-NumLock_::init(void) {
-  if (!isActive) {
-    LEDControl.next_mode();
-  }
-}
+void NumLock_::loopHook(bool postClear) {
+  if (!postClear || !isActive)
+    return;
 
-void
-NumLock_::update(void) {
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
       Key k = Layer.lookup(r, c);
@@ -46,21 +37,16 @@ NumLock_::update(void) {
   LEDControl.led_set_crgb_at(row, col, color);
 }
 
-const macro_t *
-NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
+const macro_t *NumLock_::toggle(byte row_, byte col_, uint8_t numPadLayer) {
   row = row_;
   col = col_;
 
   if (Layer.isOn(numPadLayer)) {
-    isActive = false;
-    LEDControl.set_mode(previousLEDMode);
     Layer.off(numPadLayer);
   } else {
-    isActive = true;
-    previousLEDMode = LEDControl.get_mode();
-    LEDControl.set_mode(us);
     Layer.on(numPadLayer);
   }
+  isActive = Layer.isOn(numPadLayer);
 
   return MACRO(T(KeypadNumLock), END);
 }

--- a/src/Kaleidoscope-Numlock.h
+++ b/src/Kaleidoscope-Numlock.h
@@ -7,20 +7,16 @@
 #define TOGGLENUMLOCK 0
 #define Key_ToggleNumlock M(TOGGLENUMLOCK)
 
-class NumLock_ : public LEDMode {
+class NumLock_ : public KaleidoscopePlugin {
  public:
   NumLock_(void);
 
   void begin(void) final;
 
-  void update(void) final;
-  void init(void) final;
-
   static const macro_t *toggle(byte row, byte col, uint8_t numPadLayer);
+  static void loopHook(const bool postClear);
 
  private:
-  static uint8_t previousLEDMode;
-  static uint8_t us;
   static bool isActive;
   static byte row, col;
 };

--- a/src/Kaleidoscope-Numlock.h
+++ b/src/Kaleidoscope-Numlock.h
@@ -13,11 +13,12 @@ class NumLock_ : public KaleidoscopePlugin {
 
   void begin(void) final;
 
-  static const macro_t *toggle(byte row, byte col, uint8_t numPadLayer);
+  static const macro_t *toggle();
   static void loopHook(const bool postClear);
 
+  static uint8_t numPadLayer;
+
  private:
-  static bool isActive;
   static byte row, col;
 };
 


### PR DESCRIPTION
Instead of requiring the NumLock key row and column, and the numpad layer index to be passed to `NumLock.toggle` on every call, derive the first two from Macros.row and Macros.col respectively, and the latter from a new class variable, which should be set in the `setup()` method of the sketch.

This way, `NumLock.toggle()` becomes argument-less.

This branch is on top of #3.