### PR TITLE
Highlight changed keys on the NumLock layer, not just NumPad ones

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -23,7 +23,7 @@ void NumLock_::loopHook(bool postClear) {
       Key k = Layer.lookup(r, c);
       Key layer_key = Layer.getKey(numPadLayer, r, c);
 
-      if ((k != layer_key))
+      if ((k != layer_key) || ((k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP)) && !(k.flags & RESERVED)))
         continue;
 
       LEDControl.setCrgbAt(r, c, numpad_color);

--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -21,8 +21,9 @@ void NumLock_::loopHook(bool postClear) {
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
       Key k = Layer.lookup(r, c);
+      Key layer_key = Layer.getKey(numPadLayer, r, c);
 
-      if (k.raw < Key_KeypadNumLock.raw || k.raw > Key_KeypadDot.raw)
+      if ((k != layer_key))
         continue;
 
       LEDControl.setCrgbAt(r, c, numpad_color);


### PR DESCRIPTION
As there are - or at least may be - other keys on the layer, not just NumPad ones, those should be highlighted too.

Addresses the bulk of keyboardio/Kaleidoscope#149, by comparing the looked up key with what is directly on the `numPadLayer`: if they are the same, then it is a key that we assume changed, and do the coloring. If they are different (in other words, the key on the `numPadLayer` is transparent or off), we skip the highlight.

The downside is that we highlight layer switching keys too, which we may not want. That will be addressed separately.
