### PR TITLE
Highlight only those keys that have no flag set

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -23,7 +23,7 @@ void NumLock_::loopHook(bool postClear) {
       Key k = Layer.lookup(r, c);
       Key layer_key = Layer.getKey(numPadLayer, r, c);
 
-      if ((k != layer_key) || ((k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP)) && !(k.flags & RESERVED)))
+      if ((k != layer_key) || (k.flags != KEY_FLAGS))
         continue;
 
       LEDControl.setCrgbAt(r, c, numpad_color);


### PR DESCRIPTION
Instead of trying to exclude layer keys, exclude everything with a flag. Thus, only the basic keys will receive the highlighting treatment, and the rest, `Prog`, `Any` and the layer keys will not.

Thanks to @chughes87 for the report!