### PR TITLE
Use an event loop hook instead of requiring a macro to detect NumLock

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -9,6 +9,7 @@ cRGB numpad_color = CRGB(255, 0, 0);
 
 void NumLock_::begin(void) {
   Kaleidoscope.useLoopHook(loopHook);
+  Kaleidoscope.useEventHandlerHook(eventHandlerHook);
 }
 
 void NumLock_::loopHook(bool postClear) {
@@ -35,9 +36,12 @@ void NumLock_::loopHook(bool postClear) {
   LEDControl.setCrgbAt(row, col, color);
 }
 
-const macro_t *NumLock_::toggle() {
-  row = Macros.row;
-  col = Macros.col;
+Key NumLock_::eventHandlerHook(Key key, byte row, byte col, uint8_t key_state) {
+  if (key != Key_KeypadNumLock)
+    return key;
+
+  if (!key_toggled_on(key_state))
+    return key;
 
   if (Layer.isOn(numPadLayer)) {
     Layer.off(numPadLayer);
@@ -46,7 +50,7 @@ const macro_t *NumLock_::toggle() {
     Layer.on(numPadLayer);
   }
 
-  return MACRO(T(KeypadNumLock), END);
+  return key;
 }
 
 NumLock_ NumLock;

--- a/src/Kaleidoscope-Numlock.h
+++ b/src/Kaleidoscope-Numlock.h
@@ -4,21 +4,18 @@
 #include "Kaleidoscope-Macros.h"
 #include "LEDUtils.h"
 
-#define TOGGLENUMLOCK 0
-#define Key_ToggleNumlock M(TOGGLENUMLOCK)
-
 class NumLock_ : public KaleidoscopePlugin {
  public:
   NumLock_(void) {}
 
   void begin(void) final;
 
-  static const macro_t *toggle();
-  static void loopHook(const bool postClear);
-
   static uint8_t numPadLayer;
 
  private:
+  static void loopHook(const bool postClear);
+  static Key eventHandlerHook(Key key, byte row, byte col, uint8_t key_state);
+
   static byte row, col;
 };
 


### PR DESCRIPTION
Requiring the end-user to use a macro to have the NumLock effect is a bit confusing. We can do better than that, by using an event handler hook, and catching `Keypad_NumLock` presses, and toggle on keypress.

This way, the macro is not necessary, and all the user has to do, is to use the plugin, configure `numPadLayer`, and done.

This PR *will* break the factory firmware until that sees an update. Will submit a PR against that too, in a few minutes.