### PR TITLE
Sync the NUMPAD layer state with the host

### DIFF
--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -5,15 +5,29 @@
 
 byte NumLock_::row = 255, NumLock_::col = 255;
 uint8_t NumLock_::numPadLayer;
+bool NumLock_::isOn;
 cRGB numpad_color = CRGB(255, 0, 0);
 
 void NumLock_::begin(void) {
   Kaleidoscope.useLoopHook(loopHook);
-  Kaleidoscope.useEventHandlerHook(eventHandlerHook);
 }
 
 void NumLock_::loopHook(bool postClear) {
-  if (!postClear || !Layer.isOn(numPadLayer))
+  if (!postClear)
+    return;
+
+  bool numState = !!(Keyboard.getLEDs() & LED_NUM_LOCK);
+  if (numState != isOn) {
+    isOn = numState;
+    if (isOn) {
+      Layer.on(numPadLayer);
+    } else {
+      Layer.off(numPadLayer);
+      LEDControl.set_mode(LEDControl.get_mode_index());
+    }
+  }
+
+  if (!isOn)
     return;
 
   for (uint8_t r = 0; r < ROWS; r++) {
@@ -34,23 +48,6 @@ void NumLock_::loopHook(bool postClear) {
 
   cRGB color = breath_compute();
   LEDControl.setCrgbAt(row, col, color);
-}
-
-Key NumLock_::eventHandlerHook(Key key, byte row, byte col, uint8_t key_state) {
-  if (key != Key_KeypadNumLock)
-    return key;
-
-  if (!keyToggledOn(key_state))
-    return key;
-
-  if (Layer.isOn(numPadLayer)) {
-    Layer.off(numPadLayer);
-    LEDControl.set_mode(LEDControl.get_mode_index());
-  } else {
-    Layer.on(numPadLayer);
-  }
-
-  return key;
 }
 
 NumLock_ NumLock;

--- a/src/Kaleidoscope-Numlock.cpp
+++ b/src/Kaleidoscope-Numlock.cpp
@@ -16,7 +16,7 @@ void NumLock_::loopHook(bool postClear) {
   if (!postClear)
     return;
 
-  bool numState = !!(Keyboard.getLEDs() & LED_NUM_LOCK);
+  bool numState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
   if (numState != isOn) {
     isOn = numState;
     if (isOn) {

--- a/src/Kaleidoscope-Numlock.h
+++ b/src/Kaleidoscope-Numlock.h
@@ -14,9 +14,9 @@ class NumLock_ : public KaleidoscopePlugin {
 
  private:
   static void loopHook(const bool postClear);
-  static Key eventHandlerHook(Key key, byte row, byte col, uint8_t key_state);
 
   static byte row, col;
+  static bool isOn;
 };
 
 extern NumLock_ NumLock;


### PR DESCRIPTION
Instead of trying to track numlock ourselves, rely on the host telling us what it thinks the state is. This is much more reliable than what we were doing, and hopefully fixes most of - if not all - the issues we were having with NumLock.

Depends on keyboardio/KeyboardioHID#11 and keyboardio/Arduino-HID#1.